### PR TITLE
chore: add gnome 48 to the supported versions

### DIFF
--- a/simulate-switching-workspaces-on-active-monitor@micheledaros.com/metadata.json
+++ b/simulate-switching-workspaces-on-active-monitor@micheledaros.com/metadata.json
@@ -2,7 +2,7 @@
   "description": "Simulates switching the workspace on the active monitor only. Ctrl+Alt+q switches to the previous workspace, Ctrl+Alt+a switches to the next",
   "name": "Switch workspaces on active monitor",
   "original-authors": "darosmic@gmail.com",
-  "shell-version": ["45", "46", "47"],
+  "shell-version": ["45", "46", "47", "48"],
   "url": "https://github.com/micheledaros/gnome-shell-extension-simulate-switching-workspaces-on-active-monitor",
   "uuid": "simulate-switching-workspaces-on-active-monitor@micheledaros.com",
   "settings-schema": "org.gnome.shell.extensions.simulate-switching-workspaces-on-active-monitor",


### PR DESCRIPTION
I've tested the extension via `gsettings set org.gnome.shell disable-extension-version-validation true` in a Gnome 48 (Fedora 42) VM with three virtual monitors and everything seemed to work.